### PR TITLE
Feat: Allow-moving-into-other-snakes-tail-when-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,6 @@
 - CHANGELOG.md file
 -  Added a food targeting feature
  
-# ## Fixed 
+### Fixed 
 - Refactored folder structure for clarity.
 - Fixed linting errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,27 @@
 # Changelog
 
 ## [Unreleased]
-[Fixed] Fixed linting errors
-[Added] Added and configured default prettier
-[Added] Added and configured eslint
-[Added] Added and cofigured .editorconfig
-[Added] Pull Request template
-[Added] CHANGELOG.md file
-[Added] Added a food targeting feature
-[Fixed] Refactored folder structure for clarity.
+
+### Added
+- ISSUE_TEMPLATES with templates for both user stories and tasks 
+- Tail collision prediction system
+- Ability to move into opponent tails that will move
+- Food-aware tail movement validation
+
+### Changed 
+- Updated collision detection logic in `other-snakes-collision.js`
+- Modified movement strategy to consider moving tails
+
+## [1.0.0] - 2025-04-30
+
+### Added 
+- Added and configured default prettier
+- Added and configured eslint
+- Added and cofigured .editorconfig
+- Pull Request template
+- CHANGELOG.md file
+-  Added a food targeting feature
+ 
+# ## Fixed 
+- Refactored folder structure for clarity.
+- Fixed linting errors

--- a/index.js
+++ b/index.js
@@ -68,6 +68,7 @@ function move(gameState) {
     myHead,
     gameState.board.snakes,
     gameState.you.id,
+    gameState.board.food, // Pass food data
     isMoveSafe,
   );
 

--- a/src/other-snakes-collision.js
+++ b/src/other-snakes-collision.js
@@ -1,11 +1,22 @@
 // other-snakes-collision.js
-// eslint-disable-next-line sonarjs/cognitive-complexity
-export function checkOtherSnakesCollision(myHead, opponents, myId, isMoveSafe) {
+import { checkTailCollision, isAboutToEat } from "./tail-collision.js";
+
+export function checkOtherSnakesCollision(myHead, opponents, myId, food, isMoveSafe) {
   for (const snake of opponents) {
     // Skip ourselves
     if (snake.id === myId) continue;
 
-    for (const bodyPart of snake.body) {
+    for (let i = 0; i < snake.body.length; i++) {
+      const bodyPart = snake.body[i];
+
+      // Skip the tail if it's about to move
+      const isTail = i === snake.body.length - 1;
+      const willTailMove = isTail &&
+        snake.health < 100 &&
+        !isAboutToEat(snake.body[0], food);
+
+      if (willTailMove) continue;
+
       // Check left collision
       if (myHead.x - 1 === bodyPart.x && myHead.y === bodyPart.y) {
         isMoveSafe.left = false;
@@ -24,5 +35,7 @@ export function checkOtherSnakesCollision(myHead, opponents, myId, isMoveSafe) {
       }
     }
   }
-  return isMoveSafe;
+
+  // After regular collision checks, allow moving into movable tails
+  return checkTailCollision(myHead, opponents, food, isMoveSafe);
 }

--- a/src/tail-collision.js
+++ b/src/tail-collision.js
@@ -1,0 +1,42 @@
+// tail-collision.js
+export function isAboutToEat(head, food) {
+  return food.some(f =>
+    (f.x === head.x - 1 && f.y === head.y) || // left
+    (f.x === head.x + 1 && f.y === head.y) || // right
+    (f.x === head.x && f.y === head.y - 1) || // down
+    (f.x === head.x && f.y === head.y + 1)    // up
+  );
+}
+
+export function checkTailCollision(myHead, opponents, food, isMoveSafe) {
+  for (const snake of opponents) {
+    // Skip if snake has no body
+    if (snake.body.length < 1) continue;
+
+    const tail = snake.body[snake.body.length - 1];
+    const head = snake.body[0];
+
+    // Check if tail is about to move
+    const willTailMove = (
+      snake.health < 100 && // Didn't just eat
+      !isAboutToEat(head, food) // Not about to eat next turn
+    );
+
+    if (!willTailMove) continue;
+
+    // Check if any of our possible moves would land on a movable tail
+    if (myHead.x - 1 === tail.x && myHead.y === tail.y) {
+      isMoveSafe.left = true;
+    }
+    if (myHead.x + 1 === tail.x && myHead.y === tail.y) {
+      isMoveSafe.right = true;
+    }
+    if (myHead.x === tail.x && myHead.y - 1 === tail.y) {
+      isMoveSafe.down = true;
+    }
+    if (myHead.x === tail.x && myHead.y + 1 === tail.y) {
+      isMoveSafe.up = true;
+    }
+  }
+  return isMoveSafe;
+}


### PR DESCRIPTION
## Type of Change
New feature and documentation change

## Description
Updated movement logic so that a snake can enter a tile currently occupied by another snake’s tail, but **only if** that tail is expected to move (i.e., the other snake is not about to eat food).

## Related Issues
Issue #31 

## Screenshots
--

## Other Notes
--